### PR TITLE
Global variables should be declared by defvar instead of setq

### DIFF
--- a/repeatable-motion.el
+++ b/repeatable-motion.el
@@ -31,9 +31,9 @@
 
 ;; should these be buffer local?  Evil mode doesn't make command repetition buffer
 ;; local, so for now these won't be either.
-(setq repeatable-motion--forward-func (lambda () (interactive) nil))
-(setq repeatable-motion--backward-func (lambda () (interactive) nil))
-(setq repeatable-motion--numeric-arg 1)
+(defvar repeatable-motion--forward-func (lambda () (interactive) nil))
+(defvar repeatable-motion--backward-func (lambda () (interactive) nil))
+(defvar repeatable-motion--numeric-arg 1)
 
 (defcustom repeatable-motion-define-common-motions-p t
   "If non-nil, a bunch of common motion commands will have repeatable


### PR DESCRIPTION
This causes byte-compile warnings as below.

```
repeatable-motion.el:34:7:Warning: assignment to free variable
    `repeatable-motion--forward-func'
repeatable-motion.el:35:7:Warning: assignment to free variable
    `repeatable-motion--backward-func'
repeatable-motion.el:36:7:Warning: assignment to free variable
    `repeatable-motion--numeric-arg'
```
